### PR TITLE
Allow for no spaces after t= and st= in RECORD_START regex

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var readline = require('readline');
 
-var RECORD_START = /^t=\s+(\d+)\s\[st=\s+(\d+)\]\s+(.+)$/;
+var RECORD_START = /^t=\s*(\d+)\s\[st=\s*(\d+)\]\s+(.+)$/;
 var RECORD_KEY_VALUE = /^\s+-->\s(\S+)\s=\s\"?([^\"]+)\"?/;
 var RECORD_HEADERS = /^\s+(--> )?(:?[^:]+):\s(.+)$/;
 


### PR DESCRIPTION
Current regex for RECORD_START assumes one or more spaces after t= and st= e.g.

```
t= 5687 [st=    0] +HTTP2_SESSION  [dt=10619]
```

These spaces aren't present for the later entries in longer sessions e.g.

```
t=16306 [st=10619]    HTTP2_SESSION_POOL_REMOVE_SESSION
```

Change tested against original session in repo, and the session attached

[session.ad.txt](https://github.com/rmurphey/chrome-http2-log-parser/files/48438/session.ad.txt)
